### PR TITLE
Fix text colour in header

### DIFF
--- a/developer-guide.md
+++ b/developer-guide.md
@@ -52,6 +52,8 @@ Please note:
 
 We're using Tailwind CSS.
 
+You can find the custom colours defined in tailwind.config.ts.
+
 Docs: https://tailwindcss.com/docs/styling-with-utility-classes
 
 ## Formatting

--- a/next/app/lib/components/Header.tsx
+++ b/next/app/lib/components/Header.tsx
@@ -9,8 +9,8 @@ export const Header: React.FC = () => {
         src="/bcgov_white_text.png"
         alt="BC GOV logo"
       />
-      <span className="text-xl">Zero-Emission Vehicles Reporting System</span>
-      <span className="ml-auto">Government of British Columbia</span>
+      <span className="text-xl text-white">Zero-Emission Vehicles Reporting System</span>
+      <span className="ml-auto text-white">Government of British Columbia</span>
     </div>
   );
 };

--- a/next/app/lib/components/Header.tsx
+++ b/next/app/lib/components/Header.tsx
@@ -3,14 +3,14 @@ import React from "react";
 /** Basic Header component containing the BCGOV logo and title of the application. */
 export const Header: React.FC = () => {
   return (
-    <div className="w-full bg-primaryBlue flex flex-row items-center px-4">
+    <div className="w-full bg-primaryBlue flex flex-row items-center px-4 text-white">
       <img
         className="h-30 w-60 mr-4"
         src="/bcgov_white_text.png"
         alt="BC GOV logo"
       />
-      <span className="text-xl text-white">Zero-Emission Vehicles Reporting System</span>
-      <span className="ml-auto text-white">Government of British Columbia</span>
+      <span className="text-xl">Zero-Emission Vehicles Reporting System</span>
+      <span className="ml-auto">Government of British Columbia</span>
     </div>
   );
 };


### PR DESCRIPTION
Emily informed me that the text was showing as black on her machine, this was never explicitly defined to be white and probably was only working because of something on my local machine. This should fix that.