### PR TITLE
<Row> / <Col> components to cut out some excess tailwind attributes 

### DIFF
--- a/next/app/lib/components/Header.tsx
+++ b/next/app/lib/components/Header.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Navbar } from "./Navbar";
 import { Session } from "next-auth";
+import { Row } from "./layout";
 
 export interface IHeaderProps {
   session: Session;
@@ -9,7 +10,7 @@ export interface IHeaderProps {
 export const Header: React.FC<IHeaderProps> = ({ session }) => {
   return (
     <div className="w-full flex flex-col">
-      <div className="w-full bg-primaryBlue flex flex-row items-center px-4 text-white">
+      <Row className="w-full bg-primaryBlue items-center px-4 text-white">
         <img
           className="h-[5rem] w-[12.5rem] mr-4"
           src="/bcgov_white_text.png"
@@ -17,8 +18,8 @@ export const Header: React.FC<IHeaderProps> = ({ session }) => {
         />
         <span className="text-xl">Zero-Emission Vehicles Reporting System</span>
         <span className="ml-auto">Government of British Columbia</span>
-      </div>
-      {session.user && <Navbar user={session.user} />}
+      </Row>
+      <Navbar user={session.user ?? ""} />
     </div>
   );
 };

--- a/next/app/lib/components/Header.tsx
+++ b/next/app/lib/components/Header.tsx
@@ -19,7 +19,7 @@ export const Header: React.FC<IHeaderProps> = ({ session }) => {
         <span className="text-xl">Zero-Emission Vehicles Reporting System</span>
         <span className="ml-auto">Government of British Columbia</span>
       </Row>
-      <Navbar user={session.user ?? ""} />
+      {session.user && <Navbar user={session.user} />}
     </div>
   );
 };

--- a/next/app/lib/components/Navbar.tsx
+++ b/next/app/lib/components/Navbar.tsx
@@ -4,10 +4,11 @@ import React from "react";
 import { Routes } from "../constants";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { User } from "@auth/core/types";
 import { FaAngleDown, FaAngleUp } from "react-icons/fa";
 import { keycloakSignOut } from "../actions/keycloak";
 import { Role } from "@/prisma/generated/client";
+import { User } from "../types";
+import { Row } from "./layout";
 
 export interface INavbarOption {
   label: string;
@@ -66,7 +67,7 @@ export const Navbar: React.FC<INavbarProps> = ({ user }) => {
   ];
 
   return (
-    <div className="flex flex-row w-full bg-defaultBackgroundBlue border-t-2 border-primaryYellow mr-[16rem] px-1 mb-3 text-white">
+    <Row className="w-full bg-defaultBackgroundBlue border-t-2 border-primaryYellow mr-[16rem] px-1 mb-3 text-white">
       {navItems.map((item) => {
         if (
           item.roles.some((role) => user.roles?.includes(role)) ||
@@ -107,6 +108,6 @@ export const Navbar: React.FC<INavbarProps> = ({ user }) => {
           </div>
         )}
       </div>
-    </div>
+    </Row>
   );
 };

--- a/next/app/lib/components/layout/Col.tsx
+++ b/next/app/lib/components/layout/Col.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export interface IColProps extends React.HTMLAttributes<HTMLDivElement> {
+  className?: string;
+  children: React.ReactNode;
+}
+
+/**
+* Simple component that renders a flex-col div, useful for creating grid items when paired with <Row>
+*/
+export const Col: React.FC<IColProps> = ({ children, className, ...rest }) => {
+  return <div className={`flex flex-col ${className}`} {...rest}> {children}</div >;
+}

--- a/next/app/lib/components/layout/Row.tsx
+++ b/next/app/lib/components/layout/Row.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export interface IRowProps extends React.HTMLAttributes<HTMLDivElement> {
+  className?: string;
+  children: React.ReactNode;
+}
+
+/**
+* Simple component that renders a flex-row div, useful for creating grid items when paired with <Col>
+*/
+export const Row: React.FC<IRowProps> = ({ children, className, ...rest }) => {
+  return <div className={`flex flex-row ${className}`} {...rest}> {children}</div >;
+}

--- a/next/app/lib/components/layout/index.ts
+++ b/next/app/lib/components/layout/index.ts
@@ -1,0 +1,2 @@
+export * from "./Col";
+export * from "./Row";


### PR DESCRIPTION
This is a method I have used on previous projects, less relevant as tailwind makes things easier; however, if you are trying to make a simple grid layout on a page you can now do the following:

```
<Row> 
  <Col> Col 1 </Col>
  <Col> Col 2 </Col>
</Row>
```

If one needs more style attributes you can pass tailwind attributes as usual with `<Row className="w-full">`, Row for example just always has flex-row and flex by default.