### PR TITLE
feat: 65 - zev unit balances

### DIFF
--- a/next/app/zev-unit-balance/[id]/page.tsx
+++ b/next/app/zev-unit-balance/[id]/page.tsx
@@ -1,45 +1,28 @@
-import { auth } from "@/auth";
-import { fetchBalance } from "../lib/data";
-import { prisma } from "@/lib/prisma";
-import { redirect } from "next/navigation";
+import { fetchBalance, getOrg } from "../lib/data";
 import BalanceTable from "../lib/components/BalanceTable";
 import TransactionAccordion from "../lib/components/TransactionAccordion";
 
-type Props = { params: { id: string } };
+type Props = { params: Promise<{ id: string }> };
 
 export default async function OrgBalancePage({ params }: Props) {
-  const session = await auth();
-  if (!session) redirect("/api/auth/signin");
+  const args = await params;
+  const orgId = Number(args.id);
+  const org = await getOrg(orgId);
+  const balance = await fetchBalance(orgId);
 
-  const orgId = Number(params.id);
-  if (Number.isNaN(orgId)) return <p>Invalid org ID</p>;
+  if (org && balance) {
+    return (
+      <main>
+        <h1>Balance for {org.name}</h1>
 
-  const org = await prisma.organization.findUnique({
-    where: { id: orgId },
-    select: { name: true },
-  });
-  if (!org) return <p>Organization not found</p>;
-
-  let balance: Awaited<ReturnType<typeof fetchBalance>>;
-  try {
-    balance = await fetchBalance(orgId);
-  } catch (e) {
-    if ((e as Error).message === "Unauthorized") {
-      return <p>You’re not authorized to view this organization.</p>;
-    }
-    throw e;
+        {balance === "deficit" ? (
+          <p style={{ color: "red" }}>Deficit</p>
+        ) : (
+          <BalanceTable balance={balance} />
+        )}
+        <TransactionAccordion orgId={orgId} />
+      </main>
+    );
   }
-
-  return (
-    <main>
-      <h1>Balance for {org.name}</h1>
-
-      {balance === "deficit" ? (
-        <p style={{ color: "red" }}>Deficit</p>
-      ) : (
-        <BalanceTable balance={balance} />
-      )}
-      <TransactionAccordion orgId={orgId} />
-    </main>
-  );
+  return null;
 }

--- a/next/app/zev-unit-balance/lib/components/BalanceTable.tsx
+++ b/next/app/zev-unit-balance/lib/components/BalanceTable.tsx
@@ -1,12 +1,13 @@
+import { getModelYearEnumMap } from "@/app/lib/utils/enumMaps";
+import { ZevUnitRecordsObj } from "@/lib/utils/zevUnit";
+import { ModelYear } from "@/prisma/generated/client";
 import React from "react";
 
-type Balance = Record<string, any>;
-
-function strip(prefix: string, value: string) {
-  return value.startsWith(prefix) ? value.slice(prefix.length) : value;
-}
-
-export default function BalanceTable({ balance }: { balance: Balance }) {
+export default function BalanceTable({
+  balance,
+}: {
+  balance: ZevUnitRecordsObj;
+}) {
   const subtree = balance?.CREDIT?.REPORTABLE;
   if (!subtree) return <p>No credit data.</p>;
 
@@ -18,9 +19,8 @@ export default function BalanceTable({ balance }: { balance: Balance }) {
     ...Object.keys(bRecords),
   ]);
 
-  const sortedYears = Array.from(years).sort(
-    (y1, y2) => Number(strip("MY_", y1)) - Number(strip("MY_", y2))
-  );
+  const sortedYears = Array.from(years).sort().reverse();
+  const modelYearsMap = getModelYearEnumMap();
 
   return (
     <table style={{ borderCollapse: "collapse", minWidth: "20rem" }}>
@@ -34,12 +34,12 @@ export default function BalanceTable({ balance }: { balance: Balance }) {
       <tbody>
         {sortedYears.map((y) => (
           <tr key={y}>
-            <td style={{ padding: "4px" }}>{strip("MY_", y)}</td>
+            <td style={{ padding: "4px" }}>{modelYearsMap[y]}</td>
             <td style={{ textAlign: "right", padding: "4px" }}>
-              {aRecords[y]?.toString() ?? "—"}
+              {aRecords[y as ModelYear]?.toString() ?? "—"}
             </td>
             <td style={{ textAlign: "right", padding: "4px" }}>
-              {bRecords[y]?.toString() ?? "—"}
+              {bRecords[y as ModelYear]?.toString() ?? "—"}
             </td>
           </tr>
         ))}

--- a/next/app/zev-unit-balance/lib/components/TransactionAccordion.tsx
+++ b/next/app/zev-unit-balance/lib/components/TransactionAccordion.tsx
@@ -1,15 +1,18 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { getTransactionsByComplianceYear, getComplianceYears } from "../actions";
-import type { ZevUnitTransaction } from "@/prisma/generated/client";
+import {
+  getTransactionsByComplianceYear,
+  getComplianceYears,
+  SerializedZevUnitTransaction,
+} from "../actions";
 
 export default function TransactionAccordion({ orgId }: { orgId: number }) {
   const [years, setYears] = useState<number[] | null>(null);
   const [openYear, setOpenYear] = useState<number | null>(null);
-  const [txCache, setTxCache] = useState<Record<number, ZevUnitTransaction[]>>(
-    {}
-  );
+  const [txCache, setTxCache] = useState<
+    Record<number, SerializedZevUnitTransaction[]>
+  >({});
 
   useEffect(() => {
     (async () => setYears(await getComplianceYears(orgId)))();
@@ -18,7 +21,7 @@ export default function TransactionAccordion({ orgId }: { orgId: number }) {
   const toggleYear = async (y: number) => {
     setOpenYear((prev) => (prev === y ? null : y));
     if (!txCache[y]) {
-      const tx = await getTransactionsByComplianceYear(orgId, y);
+      const tx = await getTransactionsByComplianceYear(orgId, y, "desc");
       setTxCache((prev) => ({ ...prev, [y]: tx }));
     }
   };
@@ -53,7 +56,7 @@ export default function TransactionAccordion({ orgId }: { orgId: number }) {
           >
             {openYear === y ? "▾" : "▸"} Compliance&nbsp;Year&nbsp;{y}
           </button>
-          
+
           {openYear === y && (
             <div style={{ padding: 8 }}>
               {!txCache[y] ? (
@@ -70,20 +73,25 @@ export default function TransactionAccordion({ orgId }: { orgId: number }) {
                 >
                   <thead>
                     <tr>
-                      {["ID", "Type", "Units", "Class", "Model Year", "Date"].map(
-                        (h) => (
-                          <th
-                            key={h}
-                            style={{
-                              textAlign: "left",
-                              borderBottom: "1px solid #ddd",
-                              padding: "4px",
-                            }}
-                          >
-                            {h}
-                          </th>
-                        )
-                      )}
+                      {[
+                        "ID",
+                        "Type",
+                        "Units",
+                        "Class",
+                        "Model Year",
+                        "Date",
+                      ].map((h) => (
+                        <th
+                          key={h}
+                          style={{
+                            textAlign: "left",
+                            borderBottom: "1px solid #ddd",
+                            padding: "4px",
+                          }}
+                        >
+                          {h}
+                        </th>
+                      ))}
                     </tr>
                   </thead>
                   <tbody>
@@ -91,9 +99,7 @@ export default function TransactionAccordion({ orgId }: { orgId: number }) {
                       <tr key={t.id}>
                         <td style={{ padding: "4px" }}>{t.id}</td>
                         <td style={{ padding: "4px" }}>{t.type}</td>
-                        <td
-                          style={{ padding: "4px", textAlign: "right" }}
-                        >
+                        <td style={{ padding: "4px", textAlign: "right" }}>
                           {t.numberOfUnits.toString()}
                         </td>
                         <td style={{ padding: "4px" }}>{t.zevClass}</td>

--- a/next/app/zev-unit-balance/page.tsx
+++ b/next/app/zev-unit-balance/page.tsx
@@ -1,27 +1,26 @@
-import { auth } from "@/auth";
+import { getUserInfo } from "@/auth";
 import { fetchBalance } from "./lib/data";
-import { ModelYear } from "@/prisma/generated/client";
 import BalanceTable from "./lib/components/BalanceTable";
 import TransactionAccordion from "./lib/components/TransactionAccordion";
 
 export default async function BalancePage() {
-  const session = await auth();
-  const orgId = session?.user?.organizationId || 0;
-  const currentYear = 2025
-  const yearEnum = ("MY_" + currentYear) as ModelYear;
+  const { userIsGov, userOrgId } = await getUserInfo();
+  if (!userIsGov) {
+    const balance = await fetchBalance(userOrgId);
+    if (balance) {
+      return (
+        <main>
+          <h1>Current Balance</h1>
 
-  const balance = await fetchBalance(orgId);
-
-  return (
-    <main>
-      <h1>Balance ({currentYear})</h1>
-
-      {balance === "deficit" ? (
-      <p style={{ color: "red" }}>Deficit</p>
-      ) : (
-        <BalanceTable balance={balance} />
-      )}
-      <TransactionAccordion orgId={orgId} />
-    </main>
-  );
+          {balance === "deficit" ? (
+            <p style={{ color: "red" }}>Deficit</p>
+          ) : (
+            <BalanceTable balance={balance} />
+          )}
+          <TransactionAccordion orgId={userOrgId} />
+        </main>
+      );
+    }
+  }
+  return null;
 }


### PR DESCRIPTION
Hey @JulianForeman, I made some suggested changes, and here are a few notes about them:

(1) I noticed that the numbers for the balances were off, so I made some changes there (data.ts, the `fetchBalances` function). What we want to do is, for an organization, get its most recent ending balances, then any transactions that come after that. So, for example, if they have ending balances with complianceYears 2020, 2021, and 2023, then you should be getting the 2023 ending balances, and adding to that any ZevUnitTransactions with a timestamp of Oct.1, 2024 or later (since the 2023 compliance year runs from Oct.1 2023 to Sep.30, 2024).

(2) The functions in actions.ts are actually all exposed endpoints (because of the `use server` directive), and so they need to be directly protected (you can use `getUserInfo`,  which uses `auth`).

(3) Also, in data.ts for example, you don't need to check for authentication, just authorization, since the auth middleware should redirect unauthenticated users to the main page.

(4) I noticed that the little next icon in the bottom left of the screen was complaining when I toggled the accordion sections, and that's because we are passing Decimal objects from the backend to the frontend when we call the `getTransactionsByComplianceYear` action in a client component. Please see this page (https://react.dev/reference/rsc/use-server#serializable-parameters-and-return-values) for a list of serializable values.

(5) There's some other changes I made just to make things a bit more consistent with the rest of the codebase; please let me know if you have any questions!