### PR TITLE
tim - 80 - small change

### DIFF
--- a/next/app/organizations/lib/data.ts
+++ b/next/app/organizations/lib/data.ts
@@ -11,6 +11,10 @@ export type OrganizationSparse = {
 };
 
 export const getAllSuppliers = async () => {
+  const { userIsGov } = await getUserInfo();
+  if (!userIsGov) {
+    return []
+  }
   const organizations = await prisma.organization.findMany({
     select: {
       id: true,


### PR DESCRIPTION
Hi @rogerlcleung, looks great! Just a small suggested change and a remark:

(1) I added an additional `userIsGov` check to `getAllSuppliers` (I understand you're checking in the `getOrganizations` function, but I just thought in case someone uses the `getAllSuppliers` function in the future, it'd be good to have that there).

(2) I see that for the list page you're getting all the organizations + all their ending balances and transactions, calculating their total balances, and then returning the ones that match the filters and page. I understand that if we want to filter and sort by the balance columns, there's probably no other reasonable way to do this, but I have some scalability concerns (even though the number of suppliers is not expected to grow by much over time, their "child data" (e.g. number of transactions) might).

The thing we try to do when using server-side pagination, filtering, and sorting is to try to pass those things to the database (e.g. in Prisma, that's by using the `skip`, `take`, `where`, `orderBy` clauses) as it is usually more efficient for the database to do those things. In zeva1, in places where we do use these sorts of "server-side pagination/filtering/sorting" tables, we've disabled filtering and sorting for columns where it's not feasible to do these things without getting all the data.

We can leave this as it is for now, but I just wanted to flag for you that if you work on another table in zeva2, and you encounter similar columns as these "balance" ones, you can consider just disabling the ability to filter or sort using them, or even not displaying them. Please let me know if you have any questions! 
