### PR TITLE
independent RoleSelector component

### DIFF
--- a/next/app/lib/components/Modal.tsx
+++ b/next/app/lib/components/Modal.tsx
@@ -10,7 +10,7 @@ import {
   faCircleInfo,
 } from "@fortawesome/free-solid-svg-icons";
 
-type ModalType = "confirmation" | "error" |  "info" | "warning";
+type ModalType = "confirmation" | "error" | "info" | "warning";
 
 export type ModalProps = {
   modalType: ModalType;
@@ -22,6 +22,8 @@ export type ModalProps = {
   showModal: boolean;
   title?: string;
   content?: string;
+  disablePrimaryButton: boolean;
+  disableSecondaryButton: boolean;
 };
 
 const modalTypesMap: Readonly<
@@ -55,7 +57,7 @@ const modalTypesMap: Readonly<
 const cancelBtnClasses =
   "inline-flex items-center rounded-lg border border-dividerDark bg-white px-4 py-2 text-sm font-medium text-secondaryText hover:bg-disabledSurface focus:outline-none focus:ring-2 focus:ring-gray-400";
 
-export default function Modal({
+export function Modal({
   modalType,
   cancelLabel = "Cancel",
   confirmLabel = "Confirm",
@@ -65,6 +67,8 @@ export default function Modal({
   showModal,
   title = "Confirm",
   content = "Are you sure you want to do this action?",
+  disablePrimaryButton,
+  disableSecondaryButton,
 }: ModalProps) {
   return (
     <>
@@ -85,7 +89,11 @@ export default function Modal({
         >
           <div className="flex justify-between items-center">
             {modalTypesMap[modalType].icon}
-            <FontAwesomeIcon icon={faXmark} className="cursor-pointer" onClick={handleCancel} />
+            <FontAwesomeIcon
+              icon={faXmark}
+              className="cursor-pointer"
+              onClick={handleCancel}
+            />
           </div>
           <h3 className="text-xl font-bold text-primaryText py-4">{title}</h3>
           <div className="text-base font-bold">{content}</div>
@@ -95,8 +103,9 @@ export default function Modal({
               id="cancel"
               onClick={handleCancel}
               type="button"
+              disabled={disableSecondaryButton}
             >
-              {cancelLabel}
+              {disableSecondaryButton ? "..." : cancelLabel}
             </button>
             {modalType !== "info" && (
               <button
@@ -104,8 +113,9 @@ export default function Modal({
                 id="confirm"
                 type="button"
                 onClick={handleSubmit}
+                disabled={disablePrimaryButton}
               >
-                {confirmLabel}
+                {disablePrimaryButton ? "..." : confirmLabel}
               </button>
             )}
           </div>

--- a/next/app/users/lib/components/RoleSelector.tsx
+++ b/next/app/users/lib/components/RoleSelector.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { Modal } from "@/app/lib/components/Modal";
+import { getRoleEnumsToStringsMap } from "@/app/lib/utils/enumMaps";
+import { Role } from "@/prisma/generated/client";
+import {
+  Dispatch,
+  SetStateAction,
+  useCallback,
+  useMemo,
+  useState,
+  useTransition,
+} from "react";
+import { updateRoles } from "../actions";
+import { govRoles, supplierRoles } from "../constants";
+import { validateRoles } from "../utilsClient";
+
+export const RoleSelector = (props: {
+  // if userId is undefined, then we're using this component as part of the "create user" process;
+  // otherwise, it is used as part of the "update user" process
+  userId?: number;
+  govOrSupplier: "gov" | "supplier";
+  roles: Role[];
+  setRoles: Dispatch<SetStateAction<Role[]>>;
+  setError: Dispatch<SetStateAction<string>>;
+}) => {
+  const [roleInQuestion, setRoleInQuestion] = useState<{
+    role: Role;
+    addOrRemove: "add" | "remove";
+  } | null>(null);
+  const [showModal, setShowModal] = useState<boolean>(false);
+  const [isPending, startTransition] = useTransition();
+
+  const roles: readonly Role[] = useMemo(() => {
+    if (props.govOrSupplier === "gov") {
+      return govRoles;
+    } else if (props.govOrSupplier === "supplier") {
+      return supplierRoles;
+    }
+    return [];
+  }, [props.govOrSupplier]);
+
+  const rolesMap = useMemo(() => {
+    return getRoleEnumsToStringsMap();
+  }, []);
+
+  const handleRoleCheck = useCallback(
+    (role: Role, checked: boolean) => {
+      if (props.userId === undefined) {
+        props.setRoles((prev) => {
+          if (prev.includes(role)) {
+            return prev.filter((element) => element !== role);
+          }
+          return [...prev, role];
+        });
+      } else {
+        setRoleInQuestion({ role, addOrRemove: checked ? "add" : "remove" });
+        setShowModal(true);
+      }
+    },
+    [props.userId, props.setRoles],
+  );
+
+  const handleCancel = useCallback(() => {
+    setRoleInQuestion(null);
+    setShowModal(false);
+  }, []);
+
+  const updateUserRoles = useCallback(() => {
+    props.setError("");
+    startTransition(async () => {
+      try {
+        if (props.userId === undefined || !roleInQuestion) {
+          throw new Error("Cannot update user roles!");
+        }
+        if (roleInQuestion.addOrRemove === "add") {
+          const newRoles = [...props.roles, roleInQuestion.role];
+          validateRoles(newRoles);
+        }
+        const resp = await updateRoles(
+          props.userId,
+          roleInQuestion.role,
+          roleInQuestion.addOrRemove,
+        );
+        if (resp.responseType === "error") {
+          props.setError(resp.message);
+        } else {
+          props.setRoles(resp.data);
+        }
+      } catch (e) {
+        if (e instanceof Error) {
+          props.setError(e.message);
+        }
+      }
+      setShowModal(false);
+    });
+  }, [props.userId, roleInQuestion, props.setError]);
+
+  return (
+    <>
+      <div className="flex items-center py-2 my-2">
+        <label className="w-72">Roles</label>
+        {roles.map((role) => (
+          <label className="w-72" key={role}>
+            <input
+              className="border p-2 w-full"
+              type="checkbox"
+              checked={props.roles.includes(role)}
+              onChange={(e) => handleRoleCheck(role, e.target.checked)}
+            />
+            {rolesMap[role]}
+          </label>
+        ))}
+      </div>
+      <Modal
+        showModal={showModal}
+        modalType="confirmation"
+        handleCancel={handleCancel}
+        handleSubmit={updateUserRoles}
+        title="User Roles Change"
+        confirmLabel="Yes"
+        content="You are about to modify this user's roles. Are you sure you want to proceed?"
+        disablePrimaryButton={isPending}
+        disableSecondaryButton={isPending}
+      />
+    </>
+  );
+};

--- a/next/app/users/lib/components/UserForm.tsx
+++ b/next/app/users/lib/components/UserForm.tsx
@@ -12,6 +12,7 @@ import {
   DataOrErrorActionResponse,
   ErrorOrSuccessActionResponse,
 } from "@/app/lib/utils/actionResponse";
+import { RoleSelector } from "./RoleSelector";
 
 export const UserForm = ({
   user,
@@ -60,15 +61,6 @@ export const UserForm = ({
     });
   }, []);
 
-  const toggleRole = useCallback((role: Role) => {
-    setRoles((prev) => {
-      if (prev.includes(role)) {
-        return prev.filter((element) => element !== role);
-      }
-      return [...prev, role];
-    });
-  }, []);
-
   const toggleNotification = useCallback((notification: Notification) => {
     setNotifications((prev) => {
       if (prev.includes(notification)) {
@@ -77,34 +69,6 @@ export const UserForm = ({
       return [...prev, notification];
     });
   }, []);
-
-const roleUpdate = useCallback(
-    async (role: Role, willAdd: boolean) => {
-      const nextRoles = willAdd
-        ? (roles.includes(role) ? roles : [...roles, role])
-        : roles.filter((r) => r !== role);
-
-      const prevRoles = roles;
-      setRoles(nextRoles);
-
-      if (!user) return;
-
-      startTransition(async () => {
-        try {
-          const payload = getUserPayload(form, nextRoles, notifications);
-          const resp = await updateUser(user.id, payload);
-          if (resp.responseType === "error") {
-            throw new Error(resp.message);
-          }
-        } catch (e) {
-          setRoles(prevRoles);
-          if (e instanceof Error) setError(e.message);
-          else setError("Failed to update user roles.");
-        }
-      });
-    },
-    [roles, notifications, form, user]
-  );
 
   const handleSubmit = useCallback(() => {
     startTransition(async () => {
@@ -161,13 +125,17 @@ const roleUpdate = useCallback(
 
       <UserFormFields
         form={form}
-        selectedRoles={roles}
-        govRoles={form.organizationId === govOrgId}
         notifications={notifications}
         onChange={handleChange}
-        toggleRole={toggleRole}
         toggleNotification={toggleNotification}
-        roleUpdate={roleUpdate}
+      />
+
+      <RoleSelector
+        userId={user ? user.id : undefined}
+        govOrSupplier={form.organizationId === govOrgId ? "gov" : "supplier"}
+        roles={roles}
+        setRoles={setRoles}
+        setError={setError}
       />
 
       <div className="pt-4 flex gap-4">

--- a/next/app/users/lib/components/UserFormFields.tsx
+++ b/next/app/users/lib/components/UserFormFields.tsx
@@ -1,47 +1,21 @@
 "use client";
 
-import {
-  getNotificationEnumsToStringsMap,
-  getRoleEnumsToStringsMap,
-} from "@/app/lib/utils/enumMaps";
+import { getNotificationEnumsToStringsMap } from "@/app/lib/utils/enumMaps";
 import { Notification, Role } from "@/prisma/generated/client";
 import { useMemo, useState } from "react";
-import Modal from "../../../lib/components/Modal";
+import { Modal } from "@/app/lib/components/Modal";
 
 export function UserFormFields({
   form,
-  selectedRoles,
-  govRoles,
   notifications,
   onChange,
-  toggleRole,
   toggleNotification,
-  roleUpdate,
 }: {
-  form: any;
-  selectedRoles: Role[];
-  govRoles: boolean;
+  form: Partial<Record<string, string>>;
   notifications: Notification[];
   onChange: (field: string, value: any) => void;
-  toggleRole: (role: Role) => void;
   toggleNotification: (role: Notification) => void;
-  roleUpdate: (role: Role, willAdd: boolean) => void;
 }) {
-  const rolesMap = useMemo(() => {
-    return getRoleEnumsToStringsMap();
-  }, []);
-
-  const availableRoles = useMemo(() => {
-    if (govRoles) {
-      return [Role.ADMINISTRATOR, Role.DIRECTOR, Role.ENGINEER_ANALYST];
-    }
-    return [
-      Role.ORGANIZATION_ADMINISTRATOR,
-      Role.SIGNING_AUTHORITY,
-      Role.ZEVA_USER,
-    ];
-  }, [govRoles]);
-
   const notificationsMap = useMemo(() => {
     return getNotificationEnumsToStringsMap();
   }, []);
@@ -49,9 +23,6 @@ export function UserFormFields({
   const isActive = form.isActive === "true";
   const [showStatusModal, setShowStatusModal] = useState(false);
   const [pendingActive, setPendingActive] = useState<boolean | null>(null);
-  const [showRoleModal, setShowRoleModal] = useState(false);
-  const [pendingRole, setPendingRole] = useState<Role | null>(null);
-  const [pendingRoleWillBeAdded, setPendingRoleWillBeAdded] = useState<boolean | null>(null);
 
   const handleActiveIntent = (nextChecked: boolean) => {
     setPendingActive(nextChecked);
@@ -69,34 +40,6 @@ export function UserFormFields({
     setShowStatusModal(false);
     setPendingActive(null);
   };
-
-  const handleRoleIntent = (role: Role, nextChecked: boolean) => {
-    setPendingRole(role);
-    setPendingRoleWillBeAdded(nextChecked);
-    setShowRoleModal(true);
-  };
-
-  const cancelRoleChange = () => {
-    setShowRoleModal(false);
-    setPendingRole(null);
-    setPendingRoleWillBeAdded(null);
-  };
-
-  const confirmRoleChange = async () => {
-    if (pendingRole == null || pendingRoleWillBeAdded == null) return;
-
-    await Promise.resolve(roleUpdate(pendingRole, pendingRoleWillBeAdded));
-
-    setShowRoleModal(false);
-    setPendingRole(null);
-    setPendingRoleWillBeAdded(null);
-  };
-
-  const roleModalTitle = pendingRoleWillBeAdded
-    ? "Confirm: Add Role"
-    : "Confirm: Remove Role";
-  const roleModalConfirmLabel = pendingRoleWillBeAdded ? "Add Role" : "Remove Role";
-  const roleModalType = pendingRoleWillBeAdded ? "confirmation" : "error";
 
   const statusModalTitle = pendingActive
     ? "Confirm: Activate User"
@@ -161,36 +104,9 @@ export function UserFormFields({
         confirmLabel={modalConfirmLabel}
         modalType={modalConfirmClass}
         content={"Are you sure you want to update this user?"}
+        disablePrimaryButton={false}
+        disableSecondaryButton={false}
       />
-      <div className="flex items-center py-2 my-2">
-        <label className="w-72">Roles</label>
-        {availableRoles.map((role) => (
-          <label className="w-72" key={role}>
-            <input
-              className="border p-2 w-full"
-              type="checkbox"
-              checked={selectedRoles.includes(role)}
-              onChange={(e) => handleRoleIntent(role, e.target.checked)}
-            />
-            {rolesMap[role]}
-          </label>
-        ))}
-      </div>
-
-      <Modal
-        showModal={showRoleModal}
-        handleCancel={cancelRoleChange}
-        handleSubmit={confirmRoleChange}
-        title={roleModalTitle}
-        confirmLabel={roleModalConfirmLabel}
-        modalType={roleModalType}
-        content={
-          pendingRoleWillBeAdded
-            ? "Are you sure you want to grant this role to the user?"
-            : "Are you sure you want to remove this role from the user?"
-        }
-      />
-      
       <div className="flex items-center py-2 my-2">
         <label className="w-72">Notifications</label>
         {Object.values(Notification).map((value) => (

--- a/next/app/users/lib/utils.ts
+++ b/next/app/users/lib/utils.ts
@@ -3,19 +3,9 @@ import { getUserInfo } from "@/auth";
 import { UserWithOrg } from "@/lib/data/user";
 import { getString } from "@/lib/utils/urlSearchParams";
 import { Prisma, Role } from "@/prisma/generated/client";
-import { ActiveFilter } from "./constants";
+import { ActiveFilter, govRoles, supplierRoles } from "./constants";
 
 export const userConfiguredCorrectly = (user: UserWithOrg) => {
-  const govRoles: Role[] = [
-    Role.ADMINISTRATOR,
-    Role.ENGINEER_ANALYST,
-    Role.DIRECTOR,
-  ];
-  const supplierRoles: Role[] = [
-    Role.ORGANIZATION_ADMINISTRATOR,
-    Role.SIGNING_AUTHORITY,
-    Role.ZEVA_USER,
-  ];
   const userIsGov = user.organization.isGovernment;
   const userRoles = user.roles;
   if (userIsGov && userRoles.some((role) => supplierRoles.includes(role))) {

--- a/next/app/users/lib/utilsClient.ts
+++ b/next/app/users/lib/utilsClient.ts
@@ -20,11 +20,7 @@ export const getUserPayload = (
   if (Number.isNaN(orgId)) {
     throw new Error("Org ID is not a number!");
   }
-  if (roles.includes(Role.DIRECTOR) && roles.includes(Role.ENGINEER_ANALYST)) {
-    throw new Error(
-      "A user cannot have both the Director and Engineer/Analyst roles!",
-    );
-  }
+  validateRoles(roles);
   return {
     organizationId: orgId,
     firstName: data.firstName,
@@ -35,4 +31,12 @@ export const getUserPayload = (
     roles,
     notifications,
   };
+};
+
+export const validateRoles = (roles: Role[]) => {
+  if (roles.includes(Role.DIRECTOR) && roles.includes(Role.ENGINEER_ANALYST)) {
+    throw new Error(
+      "A user cannot have both the Director and Engineer/Analyst roles!",
+    );
+  }
 };


### PR DESCRIPTION
Hi @JulianForeman, I took a look at your PR, and what I noticed is that we're not actually `awaiting` the call to the `roleUpdate` function; the `await` that appears inside it is part of the callback function being passed to `startTransition`, so when you `await roleUpdate()` of `await Promise.resolve(roleUpdate())`, it doesn't actually wait for the action to finish, which I think was the intention.

Also, I noticed that when we create a new user, we still get the Modal popups, which I'm not sure is what we want (the card isn't very clear about this, I think).

Based on the figma mockup and the issues above, I think the best thing to do is just to have an independent `RoleSelector` component, which is what this PR does; please have a look and let me know if you have any questions!

If it looks good to you, you can just merge this PR into yours since this PR is targeted against your `task/205/role-change-confirmation-modal` branch; you don't have to close your original PR!

