### PR TITLE
chore: upgrade setup-node and upload-artifact to Node.js 24 versions

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.3.0
         with:
           node-version: "20"
           cache: "npm"
@@ -56,7 +56,7 @@ jobs:
 
       - name: Upload coverage reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: coverage-report
           path: ./next/coverage
@@ -80,7 +80,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.3.0
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/hotfix-test.yml
+++ b/.github/workflows/hotfix-test.yml
@@ -54,7 +54,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.3.0
         with:
           node-version: "20"
           cache: "npm"
@@ -68,7 +68,7 @@ jobs:
 
       - name: Upload coverage reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: coverage-report-hotfix
           path: ./next/coverage
@@ -93,7 +93,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.3.0
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/pr-commit-lint.yaml
+++ b/.github/workflows/pr-commit-lint.yaml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.3.0
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.3.0
         with:
           node-version: "20"
           cache: "npm"
@@ -46,7 +46,7 @@ jobs:
 
       - name: Upload coverage reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: coverage-report
           path: ./next/coverage


### PR DESCRIPTION
Bump actions/setup-node from v4 to v6.3.0 and actions/upload-artifact from v4 to v7.0.0 to resolve remaining Node.js 20 deprecation warnings.