### PR TITLE
feat: Updating Zev Models Tabs #415

### DIFF
--- a/next/app/home/lib/services.ts
+++ b/next/app/home/lib/services.ts
@@ -17,6 +17,7 @@ import { Routes } from "@/app/lib/constants";
 import { mapOfStatusToSupplierStatus as myrMap } from "@/app/compliance-reporting/lib/model-year-reports/constants";
 import { mapOfStatusToSupplierStatus as caMap } from "@/app/zev-unit-activities/lib/credit-applications/constants";
 import { mapOfStatusToSupplierStatus as ctMap } from "@/app/zev-unit-activities/lib/credit-transfers/constants";
+import { getZevModelDetailsRoute } from "@/app/zev-models/lib/routes";
 
 export const getSupplierActionRequiredCounts = async (userOrgId: number) => {
   const myrPromise = prisma.modelYearReport.count({
@@ -374,9 +375,7 @@ export const getSupplierZevModelActionRequiredItems = async (
         ? getIsoYmdString(vehicle.VehicleHistory[0].timestamp)
         : undefined,
       status: statusMap[vehicle.status] ?? "",
-      route: vehicle.isActive
-        ? `${Routes.ActiveZevModels}/${vehicle.id}/details`
-        : `${Routes.InactiveZevModels}/${vehicle.id}/details`,
+      route: getZevModelDetailsRoute(vehicle),
       cta: "View",
     };
   });
@@ -598,9 +597,7 @@ export const getSupplierZevModelInProgressItems = async (
         ? getIsoYmdString(vehicle.VehicleHistory[0].timestamp)
         : undefined,
       status: statusMap[vehicle.status] ?? "",
-      route: vehicle.isActive
-        ? `${Routes.ActiveZevModels}/${vehicle.id}/details`
-        : `${Routes.InactiveZevModels}/${vehicle.id}/details`,
+      route: getZevModelDetailsRoute(vehicle),
       cta: "View",
     };
   });
@@ -835,9 +832,7 @@ export const getSupplierZevModelForAwarenessItems = async (
         ? getIsoYmdString(vehicle.VehicleHistory[0].timestamp)
         : undefined,
       status: statusMap[vehicle.status] ?? "",
-      route: vehicle.isActive
-        ? `${Routes.ActiveZevModels}/${vehicle.id}/details`
-        : `${Routes.InactiveZevModels}/${vehicle.id}/details`,
+      route: getZevModelDetailsRoute(vehicle),
       cta: "View",
     };
   });

--- a/next/app/lib/components/LowerNavbarWrapper.tsx
+++ b/next/app/lib/components/LowerNavbarWrapper.tsx
@@ -13,7 +13,8 @@ export const LowerNavbarWrapper = (props: {
   switch (props.type) {
     case "zevModel":
       if (
-        pathname === Routes.ActiveZevModels ||
+        pathname === Routes.ValidatedZevModels ||
+        pathname === Routes.SubmittedZevModels ||
         pathname === Routes.InactiveZevModels
       ) {
         return props.navbar;

--- a/next/app/lib/components/PrimaryNavbar.tsx
+++ b/next/app/lib/components/PrimaryNavbar.tsx
@@ -27,7 +27,7 @@ export const PrimaryNavbar = (props: { userIsGov: boolean }) => {
       },
       {
         label: "ZEV Models",
-        route: Routes.ActiveZevModels,
+        route: Routes.ValidatedZevModels,
       },
       ...(props.userIsGov
         ? [{ label: "Vehicle Suppliers", route: Routes.VehicleSuppliers }]

--- a/next/app/lib/constants/Routes.ts
+++ b/next/app/lib/constants/Routes.ts
@@ -16,7 +16,8 @@ export enum Routes {
   ZevUnitTransactions = "/zev-unit-activities/zev-unit-transactions",
 
   // zev models
-  ActiveZevModels = "/zev-models/active",
+  ValidatedZevModels = "/zev-models/validated",
+  SubmittedZevModels = "/zev-models/submitted",
   InactiveZevModels = "/zev-models/inactive",
   NewZevModels = "/zev-models/new",
 

--- a/next/app/zev-models/[slug]/layout.tsx
+++ b/next/app/zev-models/[slug]/layout.tsx
@@ -1,12 +1,9 @@
 import { LowerNavbarWrapper } from "@/app/lib/components/LowerNavbarWrapper";
 import { SecondaryNavbar } from "@/app/lib/components/SecondaryNavbar";
-import { Routes } from "@/app/lib/constants";
+import { zevModelTabs } from "../lib/routes";
 
 const Layout = (props: { children: React.ReactNode }) => {
-  const items = [
-    { label: "Active", route: Routes.ActiveZevModels },
-    { label: "Inactive", route: Routes.InactiveZevModels },
-  ];
+  const items = zevModelTabs.map(({ label, route }) => ({ label, route }));
   const navbar = <SecondaryNavbar items={items} />;
 
   return (

--- a/next/app/zev-models/[slug]/page.tsx
+++ b/next/app/zev-models/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { getUserInfo } from "@/auth";
 import Link from "next/link";
 import { Button } from "@/app/lib/components";
 import { Routes } from "@/app/lib/constants";
+import { isZevModelTab } from "../lib/routes";
 
 const Page = async (props: {
   params: Promise<{ slug: string }>;
@@ -17,7 +18,7 @@ const Page = async (props: {
   const searchParams = await props.searchParams;
   const { page, pageSize, filters, sorts } = getPageParams(searchParams, 1, 10);
 
-  if (slug === "active" || slug === "inactive") {
+  if (isZevModelTab(slug)) {
     return (
       <Suspense fallback={<LoadingSkeleton />}>
         <VehicleList

--- a/next/app/zev-models/lib/components/AnalystActions.tsx
+++ b/next/app/zev-models/lib/components/AnalystActions.tsx
@@ -39,9 +39,11 @@ export const AnalystActions = (props: {
           setError(response.message);
         } else {
           if (newStatus === VehicleStatus.VALIDATED) {
-            router.refresh();
+            router.push(
+              `${Routes.ValidatedZevModels}/${props.vehicleId}/details`,
+            );
           } else {
-            router.push(Routes.InactiveZevModels);
+            router.push(Routes.SubmittedZevModels);
           }
         }
       });

--- a/next/app/zev-models/lib/components/SupplierActions.tsx
+++ b/next/app/zev-models/lib/components/SupplierActions.tsx
@@ -31,13 +31,13 @@ export const SupplierActions = (props: {
       if (response.responseType === "error") {
         setError(response.message);
       } else {
-        router.push(Routes.ActiveZevModels);
+        router.push(Routes.SubmittedZevModels);
       }
     });
   }, [props.vehicleId]);
 
   const handleGoToEdit = useCallback(() => {
-    router.push(`${Routes.InactiveZevModels}/${props.vehicleId}/edit`);
+    router.push(`${Routes.SubmittedZevModels}/${props.vehicleId}/edit`);
   }, [props.vehicleId]);
 
   const handleSubmit = useCallback(() => {
@@ -71,7 +71,13 @@ export const SupplierActions = (props: {
         if (response.responseType === "error") {
           setError(response.message);
         } else {
-          router.refresh();
+          router.push(
+            `${
+              type === "activate"
+                ? Routes.ValidatedZevModels
+                : Routes.InactiveZevModels
+            }/${props.vehicleId}/details`,
+          );
         }
       });
     },

--- a/next/app/zev-models/lib/components/VehicleForm.tsx
+++ b/next/app/zev-models/lib/components/VehicleForm.tsx
@@ -121,7 +121,7 @@ export const VehicleForm = (props: {
           throw new Error(response.message);
         }
         const vehicleId = response.data;
-        router.push(`${Routes.InactiveZevModels}/${vehicleId}/details`);
+        router.push(`${Routes.SubmittedZevModels}/${vehicleId}/details`);
       } catch (e) {
         if (e instanceof Error) {
           setError(e.message);

--- a/next/app/zev-models/lib/components/VehicleList.tsx
+++ b/next/app/zev-models/lib/components/VehicleList.tsx
@@ -1,9 +1,12 @@
 import { getVehicles, VehicleSparse } from "../data";
 import { redirect } from "next/navigation";
-import { Routes } from "@/app/lib/constants";
 import { VehicleTable } from "./VehicleTable";
 import { getUserInfo } from "@/auth";
 import { ReactNode } from "react";
+import {
+  getZevModelTabRoute,
+  ZevModelTab,
+} from "@/app/zev-models/lib/routes";
 
 export type VehicleSparseSerialized = Omit<
   VehicleSparse,
@@ -13,7 +16,7 @@ export type VehicleSparseSerialized = Omit<
 };
 
 export const VehicleList = async (props: {
-  type: "active" | "inactive";
+  type: ZevModelTab;
   page: number;
   pageSize: number;
   filters: Record<string, string>;
@@ -23,11 +26,7 @@ export const VehicleList = async (props: {
   const { userIsGov } = await getUserInfo();
   const navigationAction = async (id: number) => {
     "use server";
-    if (props.type === "active") {
-      redirect(`${Routes.ActiveZevModels}/${id}/details`);
-    } else if (props.type === "inactive") {
-      redirect(`${Routes.InactiveZevModels}/${id}/details`);
-    }
+    redirect(`${getZevModelTabRoute(props.type)}/${id}/details`);
   };
   const [vehicles, totalNumberOfVehicles] = await getVehicles(
     props.type,

--- a/next/app/zev-models/lib/data.ts
+++ b/next/app/zev-models/lib/data.ts
@@ -2,6 +2,7 @@ import { getUserInfo } from "@/auth";
 import { getOrderByClause, getWhereClause } from "./utilsServer";
 import { prisma } from "@/lib/prisma";
 import { VehicleStatus } from "@/prisma/generated/enums";
+import { ZevModelTab } from "./routes";
 import {
   OrganizationModel,
   VehicleModel,
@@ -18,7 +19,7 @@ export type VehicleSparse = Omit<
 // page is 1-based
 // currently, this function is not used with SSR, so it is important to select only the data you need!
 export const getVehicles = async (
-  type: "active" | "inactive",
+  type: ZevModelTab,
   page: number,
   pageSize: number,
   filters: { [key: string]: string },
@@ -48,13 +49,27 @@ export const getVehicles = async (
     select = { ...select, organization: { select: { name: true } } };
     where.NOT = {
       status: {
-        in: [VehicleStatus.DRAFT, VehicleStatus.RETURNED_TO_SUPPLIER],
+        in: [VehicleStatus.DRAFT],
       },
     };
   } else {
     where.organizationId = userOrgId;
   }
-  where.isActive = type === "active";
+  switch (type) {
+    case "validated":
+      where.status = VehicleStatus.VALIDATED;
+      where.isActive = true;
+      break;
+    case "submitted":
+      where.status = {
+        in: [VehicleStatus.SUBMITTED, VehicleStatus.RETURNED_TO_SUPPLIER],
+      };
+      break;
+    case "inactive":
+      where.status = VehicleStatus.VALIDATED;
+      where.isActive = false;
+      break;
+  }
   return await prisma.$transaction([
     prisma.vehicle.findMany({
       skip,
@@ -86,7 +101,7 @@ export const getVehicle = async (
   } else {
     whereClause.NOT = {
       status: {
-        in: [VehicleStatus.DRAFT, VehicleStatus.RETURNED_TO_SUPPLIER],
+        in: [VehicleStatus.DRAFT],
       },
     };
   }
@@ -116,7 +131,7 @@ export const getVehicleHistories = async (vehicleId: number) => {
     whereClause.NOT = {
       vehicle: {
         status: {
-          in: [VehicleStatus.DRAFT, VehicleStatus.RETURNED_TO_SUPPLIER],
+          in: [VehicleStatus.DRAFT],
         },
       },
     };

--- a/next/app/zev-models/lib/routes.ts
+++ b/next/app/zev-models/lib/routes.ts
@@ -1,0 +1,39 @@
+import { Routes } from "@/app/lib/constants";
+import { VehicleStatus } from "@/prisma/generated/enums";
+
+export type ZevModelTab = "validated" | "submitted" | "inactive";
+
+export const zevModelTabs: {
+  label: string;
+  slug: ZevModelTab;
+  route: Routes;
+}[] = [
+  { label: "Validated", slug: "validated", route: Routes.ValidatedZevModels },
+  { label: "Submitted", slug: "submitted", route: Routes.SubmittedZevModels },
+  { label: "Inactive", slug: "inactive", route: Routes.InactiveZevModels },
+];
+
+export const isZevModelTab = (slug: string): slug is ZevModelTab => {
+  return zevModelTabs.some((tab) => tab.slug === slug);
+};
+
+export const getZevModelTabRoute = (tab: ZevModelTab): Routes => {
+  return (
+    zevModelTabs.find((item) => item.slug === tab)?.route ??
+    Routes.SubmittedZevModels
+  );
+};
+
+export const getZevModelDetailsRoute = (vehicle: {
+  id: number;
+  status: VehicleStatus;
+  isActive: boolean;
+}) => {
+  if (vehicle.status === VehicleStatus.VALIDATED) {
+    return `${
+      vehicle.isActive ? Routes.ValidatedZevModels : Routes.InactiveZevModels
+    }/${vehicle.id}/details`;
+  }
+
+  return `${Routes.SubmittedZevModels}/${vehicle.id}/details`;
+};


### PR DESCRIPTION
- Replaced the ZEV Models Active tab with lifecycle-based tabs: Validated, Submitted, and Inactive.

- Updated model list filtering so each model appears in exactly one tab based on status.

- Added shared ZEV model route helpers for tab validation, tab labels, and detail-page routing.

- Updated navigation and redirects to use the new tab routes after create, edit, validate, activate, and deactivate actions.

- Updated dashboard/home ZEV model links to route users to the correct tab.