### PR TITLE
fix: 482 - some suggested changes

### DIFF
--- a/next/app/layout.tsx
+++ b/next/app/layout.tsx
@@ -21,7 +21,9 @@ export default async function RootLayout({
       <html lang="en">
         <body className="antialiased min-h-screen flex flex-col">
           <Header />
-          <main className="flex-1 overflow-auto px-6 pb-6 pt-2">{children}</main>
+          <main className="flex-1 overflow-auto px-6 pb-6 pt-2">
+            {children}
+          </main>
           <Footer />
         </body>
       </html>

--- a/next/app/lib/components/Attachments.tsx
+++ b/next/app/lib/components/Attachments.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button } from "@/app/lib/components";
-import { useCallback, useState, useTransition } from "react";
+import { Fragment, useCallback, useState, useTransition } from "react";
 import { DataOrErrorActionResponse } from "../utils/actionResponse";
 import { downloadMultiple } from "../utils/download";
 import { Attachment, AttachmentDownload } from "../constants/attachment";
@@ -12,8 +12,7 @@ export const Attachments = (props: {
   attachments: Omit<Attachment, "objectName">[];
   download: () => Promise<DataOrErrorActionResponse<AttachmentDownload[]>>;
   zipName: string;
-  className?: string;
-  label?: string;
+  includeBottomBorder?: boolean;
 }) => {
   const [isPending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
@@ -36,43 +35,41 @@ export const Attachments = (props: {
   }, [props.download, props.zipName]);
 
   return (
-    <div className={props.className}>
+    <div className="flex flex-col p-5 gap-3">
       {props.attachments.length === 0 ? (
-        <p className="text-sm text-gray-500">No attachments</p>
+        <span className="text-sm text-gray-500">No attachments</span>
       ) : (
         <>
-          <ul className="flex flex-col self-stretch">
+          <div className="flex flex-col gap-3">
             {props.attachments.map((attachment, index) => (
-              <li key={index} className="flex flex-col">
-                <div className="py-3">
-                  {props.label && (
-                    <span className="text-secondaryText leading-6">
-                      {props.label}
-                    </span>
-                  )}
-                  <span className="text-link leading-6 underline">
-                    {attachment.fileName}
-                  </span>
-                </div>
-                <div className="self-stretch h-px bg-disabledSurface" />
-              </li>
+              <Fragment key={index}>
+                <span className="text-link underline">
+                  {attachment.fileName}
+                </span>
+                <hr className="border-disabledSurface"></hr>
+              </Fragment>
             ))}
-          </ul>
+          </div>
           {error && <p className="mt-2 text-sm text-red-600">{error}</p>}
-          <Button
-            variant="secondary"
-            onClick={handleDownload}
-            disabled={isPending}
-            icon={<FontAwesomeIcon icon={faDownload} />}
-            iconPosition="right"
-          >
-            {isPending
-              ? "..."
-              : props.attachments.length > 1
-                ? "Download All"
-                : "Download"}
-          </Button>
+          <div className="flex flex-row justify-between">
+            <Button
+              variant="secondary"
+              onClick={handleDownload}
+              disabled={isPending}
+              icon={<FontAwesomeIcon icon={faDownload} />}
+              iconPosition="right"
+            >
+              {isPending
+                ? "..."
+                : props.attachments.length > 1
+                  ? "Download All"
+                  : "Download"}
+            </Button>
+          </div>
         </>
+      )}
+      {props.includeBottomBorder && (
+        <hr className="border-disabledSurface"></hr>
       )}
     </div>
   );

--- a/next/app/lib/components/CommentBox.tsx
+++ b/next/app/lib/components/CommentBox.tsx
@@ -8,22 +8,18 @@ export const CommentBox = (props: {
   subtext?: string;
 }) => {
   return (
-    <div className="flex items-start self-stretch gap-6 shadow-[0_2px_4px_0_rgba(0,0,0,0.08)]">
-      <div className="flex flex-[1_0_0] flex-col items-start rounded border border-dividerMedium">
-        <div className="flex flex-col items-start self-stretch gap-1 rounded-t bg-disabledSurface px-5 py-4">
-          <div className="self-stretch text-black text-xl font-bold leading-7">
-            {`Comment (${props.subtext ? props.subtext : "optional"})`}
-          </div>
-        </div>
-        <div className="flex flex-col items-start gap-5 self-stretch p-5 shadow-[0_4px_20px_0_rgba(177,177,177,0.10)]">
-          <textarea
-            value={props.comment}
-            onChange={(e) => props.setComment(e.target.value)}
-            placeholder="Enter a comment..."
-            rows={5}
-            className="w-full rounded border border-gray-300 p-3 text-sm text-gray-900 placeholder:text-gray-400 focus:border-blue-600 focus:outline-none"
-          />
-        </div>
+    <div className="border border-dividerMedium rounded">
+      <div className="px-5 py-4 bg-disabledBG font-bold text-xl">
+        Comment ({props.subtext ? props.subtext : "optional"})
+      </div>
+      <div className="p-5">
+        <textarea
+          value={props.comment}
+          onChange={(e) => props.setComment(e.target.value)}
+          placeholder="Enter a comment"
+          rows={5}
+          className="w-1/2 rounded border border-dividerMedium px-4 py-3 placeholder:text-disabledIcon"
+        />
       </div>
     </div>
   );

--- a/next/app/lib/components/Dropzone.tsx
+++ b/next/app/lib/components/Dropzone.tsx
@@ -94,7 +94,9 @@ export const Dropzone = (props: {
             {props.files.map((file) => (
               <tr key={`${file.name}-${file.size}-${file.lastModified}`}>
                 <td className="py-3">{file.name}</td>
-                <td className="py-3 text-center">{(file.size / 1000).toFixed(1)} KB</td>
+                <td className="py-3 text-center">
+                  {(file.size / 1000).toFixed(1)} KB
+                </td>
                 <td className="py-3 text-right">
                   <button
                     type="button"

--- a/next/app/lib/components/StatusBanner.tsx
+++ b/next/app/lib/components/StatusBanner.tsx
@@ -103,7 +103,6 @@ export const StatusBanner = ({
   secondaryText,
   className = "",
   variant,
-  ...rest
 }: IStatusBannerProps) => {
   let variantToUse = variant;
   if (!variantToUse) {
@@ -113,23 +112,14 @@ export const StatusBanner = ({
 
   return (
     <div
-      className={`flex items-start self-stretch gap-3 px-4 py-3 rounded-sm border ${styles.container} ${className}`}
-      role="status"
-      {...rest}
+      className={`flex flex-row items-center gap-3 px-4 py-3 rounded-sm border ${styles.container} ${className}`}
     >
-      <div className="flex gap-3">
-        <span className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center text-xl">
-          {styles.icon}
+      <span className="text-xl">{styles.icon}</span>
+      <div className="flex flex-col gap-3">
+        <span>
+          <span className="font-bold">{title}</span> {primaryText}
         </span>
-        <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1 text-base leading-6">
-            <span className="font-bold">{title}</span>
-            <span>{primaryText}</span>
-          </div>
-          {secondaryText && (
-            <div className="mt-2 text-sm leading-5">{secondaryText}</div>
-          )}
-        </div>
+        {secondaryText && <span className="text-sm">{secondaryText}</span>}
       </div>
     </div>
   );

--- a/next/app/zev-unit-activities/lib/credit-agreements/components/IndividualPage.tsx
+++ b/next/app/zev-unit-activities/lib/credit-agreements/components/IndividualPage.tsx
@@ -44,7 +44,6 @@ export const IndividualPage = async (props: { id: string }) => {
         </p>
         <div className={"p-2 border border-gray-300 rounded bg-white"}>
           <Attachments
-            className="mb-3"
             attachments={agreement.agreementAttachment}
             download={download}
             zipName={`agreement_${agreementId}_attachments.zip`}

--- a/next/app/zev-unit-activities/lib/credit-applications/components/ApplicationStatistics.tsx
+++ b/next/app/zev-unit-activities/lib/credit-applications/components/ApplicationStatistics.tsx
@@ -26,44 +26,81 @@ export const ApplicationStatistics = async (props: {
     return (
       <div
         key={type === "all" ? "allRecords" : "validatedRecords"}
-        className="flex flex-col items-start self-stretch"
+        className="flex flex-col border-t border-l border-r border-disabledIcon rounded-t"
       >
-        <div className="flex flex-col items-start self-stretch gap-1 px-5 py-4 rounded-t border border-disabledIcon bg-disabledSurface">
-          <span className="self-stretch text-black font-bold leading-[22px]">
-            {type === "all"
-              ? "VIN's Claimed"
-              : status === CreditApplicationStatus.APPROVED
-                ? "VINs Issued"
-                : "VINs to be Issued"}
-          </span>
+        <div className="flex flex-col px-5 py-4 bg-disabledSurface font-bold">
+          {type === "all"
+            ? "VIN's Claimed"
+            : status === CreditApplicationStatus.APPROVED
+              ? "VINs Issued"
+              : "VINs to be Issued"}
         </div>
-        <div className="overflow-x-auto self-stretch border-b border-l border-r border-disabledIcon">
-          <table className="w-full min-w-max border-collapse">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
             <thead>
               <tr>
-                <th className="h-[60px] px-4 py-3 text-left font-bold border-b border-disabledIcon whitespace-nowrap">MAKE</th>
-                <th className="h-[60px] px-4 py-3 text-left font-bold border-b border-disabledIcon whitespace-nowrap">Model Name</th>
-                <th className="h-[60px] px-4 py-3 text-left font-bold border-b border-disabledIcon whitespace-nowrap">Model Year</th>
-                <th className="h-[60px] px-4 py-3 text-left font-bold border-b border-disabledIcon whitespace-nowrap">Vehicle Class</th>
-                <th className="h-[60px] px-4 py-3 text-left font-bold border-b border-disabledIcon whitespace-nowrap">ZEV Class</th>
-                <th className="h-[60px] px-4 py-3 text-left font-bold border-b border-disabledIcon whitespace-nowrap">ZEV Type</th>
-                <th className="h-[60px] px-4 py-3 text-left font-bold border-b border-disabledIcon whitespace-nowrap">Range</th>
-                <th className="h-[60px] px-4 py-3 text-left font-bold border-b border-disabledIcon whitespace-nowrap">Number of Units p...</th>
-                <th className="h-[60px] px-4 py-3 text-left font-bold border-b border-disabledIcon whitespace-nowrap">Count</th>
+                <th className="h-[60px] px-4 py-3 text-left font-bold border-b border-disabledIcon whitespace-nowrap">
+                  Make
+                </th>
+                <th className="h-[60px] px-4 py-3 text-left font-bold border-b border-disabledIcon whitespace-nowrap">
+                  Model Name
+                </th>
+                <th className="h-[60px] px-4 py-3 text-left font-bold border-b border-disabledIcon whitespace-nowrap">
+                  Model Year
+                </th>
+                <th className="h-[60px] px-4 py-3 text-left font-bold border-b border-disabledIcon whitespace-nowrap">
+                  Vehicle Class
+                </th>
+                <th className="h-[60px] px-4 py-3 text-left font-bold border-b border-disabledIcon whitespace-nowrap">
+                  ZEV Class
+                </th>
+                <th className="h-[60px] px-4 py-3 text-left font-bold border-b border-disabledIcon whitespace-nowrap">
+                  ZEV Type
+                </th>
+                <th className="h-[60px] px-4 py-3 text-left font-bold border-b border-disabledIcon whitespace-nowrap">
+                  Range
+                </th>
+                <th className="h-[60px] px-4 py-3 text-left font-bold border-b border-disabledIcon whitespace-nowrap">
+                  Number of Units per Vehicle
+                </th>
+                <th className="h-[60px] px-4 py-3 text-left font-bold border-b border-disabledIcon whitespace-nowrap">
+                  Count
+                </th>
               </tr>
             </thead>
             <tbody>
               {records.map((record) => (
-                <tr key={crypto.randomUUID()} className="odd:bg-lightGrey even:bg-white">
-                  <td className="px-4 py-3 border-b border-disabledIcon whitespace-nowrap">{record.make}</td>
-                  <td className="px-4 py-3 border-b border-disabledIcon whitespace-nowrap">{record.modelName}</td>
-                  <td className="px-4 py-3 border-b border-disabledIcon whitespace-nowrap">{modelYearsMap[record.modelYear]}</td>
-                  <td className="px-4 py-3 border-b border-disabledIcon whitespace-nowrap">{vehicleClassesMap[record.vehicleClass]}</td>
-                  <td className="px-4 py-3 border-b border-disabledIcon whitespace-nowrap">{zevClassMap[record.zevClass]}</td>
-                  <td className="px-4 py-3 border-b border-disabledIcon whitespace-nowrap">{record.zevType}</td>
-                  <td className="px-4 py-3 border-b border-disabledIcon whitespace-nowrap">{record.range}</td>
-                  <td className="px-4 py-3 border-b border-disabledIcon whitespace-nowrap">{record.numberOfUnits.toFixed(2)}</td>
-                  <td className="px-4 py-3 border-b border-disabledIcon whitespace-nowrap">{record._count.id}</td>
+                <tr
+                  key={crypto.randomUUID()}
+                  className="odd:bg-lightGrey even:bg-white"
+                >
+                  <td className="px-4 py-3 border-b border-disabledIcon whitespace-nowrap">
+                    {record.make}
+                  </td>
+                  <td className="px-4 py-3 border-b border-disabledIcon whitespace-nowrap">
+                    {record.modelName}
+                  </td>
+                  <td className="px-4 py-3 border-b border-disabledIcon whitespace-nowrap">
+                    {modelYearsMap[record.modelYear]}
+                  </td>
+                  <td className="px-4 py-3 border-b border-disabledIcon whitespace-nowrap">
+                    {vehicleClassesMap[record.vehicleClass]}
+                  </td>
+                  <td className="px-4 py-3 border-b border-disabledIcon whitespace-nowrap">
+                    {zevClassMap[record.zevClass]}
+                  </td>
+                  <td className="px-4 py-3 border-b border-disabledIcon whitespace-nowrap">
+                    {record.zevType}
+                  </td>
+                  <td className="px-4 py-3 border-b border-disabledIcon whitespace-nowrap">
+                    {record.range}
+                  </td>
+                  <td className="px-4 py-3 border-b border-disabledIcon whitespace-nowrap">
+                    {record.numberOfUnits.toFixed(2)}
+                  </td>
+                  <td className="px-4 py-3 border-b border-disabledIcon whitespace-nowrap">
+                    {record._count.id}
+                  </td>
                 </tr>
               ))}
             </tbody>
@@ -80,36 +117,53 @@ export const ApplicationStatistics = async (props: {
     return (
       <div
         key={type === "all" ? "allCredits" : "validatedCredits"}
-        className="flex flex-col items-start self-stretch"
+        className="flex flex-col border-t border-l border-r border-disabledIcon rounded-t"
       >
-        <div className="flex flex-col items-start self-stretch gap-1 px-5 py-4 rounded-t border border-disabledIcon bg-disabledSurface">
-          <span className="self-stretch text-black font-bold leading-[22px]">
-            {type === "all"
-              ? "Credits Claimed"
-              : status === CreditApplicationStatus.APPROVED
-                ? "Credits Issued"
-                : "Credits to be Issued"}
-          </span>
+        <div className="flex flex-col px-5 py-4 bg-disabledSurface font-bold">
+          {type === "all"
+            ? "Credits Claimed"
+            : status === CreditApplicationStatus.APPROVED
+              ? "Credits Issued"
+              : "Credits to be Issued"}
         </div>
-        <div className="overflow-x-auto self-stretch border-b border-l border-r border-disabledIcon">
-          <table className="w-full min-w-max border-collapse">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
             <thead>
               <tr>
-                <th className="h-[60px] px-4 py-3 text-left font-bold border-b border-disabledIcon whitespace-nowrap">Vehicle Class</th>
-                <th className="h-[60px] px-4 py-3 text-left font-bold border-b border-disabledIcon whitespace-nowrap">ZEV Class</th>
-                <th className="h-[60px] px-4 py-3 text-left font-bold border-b border-disabledIcon whitespace-nowrap">Model Year</th>
-                <th className="h-[60px] px-4 py-3 text-left font-bold border-b border-disabledIcon whitespace-nowrap">Number of Units</th>
+                <th className="h-[60px] px-4 py-3 text-left font-bold border-b border-disabledIcon whitespace-nowrap">
+                  Vehicle Class
+                </th>
+                <th className="h-[60px] px-4 py-3 text-left font-bold border-b border-disabledIcon whitespace-nowrap">
+                  ZEV Class
+                </th>
+                <th className="h-[60px] px-4 py-3 text-left font-bold border-b border-disabledIcon whitespace-nowrap">
+                  Model Year
+                </th>
+                <th className="h-[60px] px-4 py-3 text-left font-bold border-b border-disabledIcon whitespace-nowrap">
+                  Number of Units
+                </th>
               </tr>
             </thead>
             <tbody>
               {records.map((record) => {
                 const numberOfUnits = record._sum.numberOfUnits;
                 return (
-                  <tr key={crypto.randomUUID()} className="odd:bg-lightGrey even:bg-white">
-                    <td className="px-4 py-3 border-b border-disabledIcon whitespace-nowrap">{vehicleClassesMap[record.vehicleClass]}</td>
-                    <td className="px-4 py-3 border-b border-disabledIcon whitespace-nowrap">{zevClassMap[record.zevClass]}</td>
-                    <td className="px-4 py-3 border-b border-disabledIcon whitespace-nowrap">{modelYearsMap[record.modelYear]}</td>
-                    <td className="px-4 py-3 border-b border-disabledIcon whitespace-nowrap">{numberOfUnits ? numberOfUnits.toFixed(2) : "0"}</td>
+                  <tr
+                    key={crypto.randomUUID()}
+                    className="odd:bg-lightGrey even:bg-white"
+                  >
+                    <td className="px-4 py-3 border-b border-disabledIcon whitespace-nowrap">
+                      {vehicleClassesMap[record.vehicleClass]}
+                    </td>
+                    <td className="px-4 py-3 border-b border-disabledIcon whitespace-nowrap">
+                      {zevClassMap[record.zevClass]}
+                    </td>
+                    <td className="px-4 py-3 border-b border-disabledIcon whitespace-nowrap">
+                      {modelYearsMap[record.modelYear]}
+                    </td>
+                    <td className="px-4 py-3 border-b border-disabledIcon whitespace-nowrap">
+                      {numberOfUnits ? numberOfUnits.toFixed(2) : "0"}
+                    </td>
                   </tr>
                 );
               })}
@@ -125,7 +179,7 @@ export const ApplicationStatistics = async (props: {
 
   if (!props.userIsGov) {
     return (
-      <div className="flex flex-col items-start self-stretch gap-[26px] p-5">
+      <div className="flex flex-col gap-6 p-5">
         {stats.recordStats.length > 0 &&
           getRecordsTable(stats.recordStats, "all")}
         {recordStatsValidated &&
@@ -141,7 +195,7 @@ export const ApplicationStatistics = async (props: {
   }
 
   return (
-    <div className="flex flex-col items-start self-stretch gap-[26px] p-5">
+    <div className="flex flex-col gap-6 p-5">
       {getRecordsTable(stats.recordStats, "all")}
       {recordStatsValidated && recordStatsValidated.length > 0
         ? getRecordsTable(recordStatsValidated, "validated")

--- a/next/app/zev-unit-activities/lib/credit-applications/components/CreditApplicationForm.tsx
+++ b/next/app/zev-unit-activities/lib/credit-applications/components/CreditApplicationForm.tsx
@@ -21,11 +21,7 @@ import { downloadBuffer, getFiles } from "@/app/lib/utils/download";
 import { Routes } from "@/app/lib/constants";
 import { Attachment, AttachmentDownload } from "@/app/lib/constants/attachment";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import {
-  faDownload,
-  faFloppyDisk,
-  faTrash,
-} from "@fortawesome/free-solid-svg-icons";
+import { faDownload, faFloppyDisk } from "@fortawesome/free-solid-svg-icons";
 import { PrintDownloadButton } from "@/app/lib/components/PrintDownloadButton";
 
 export const CreditApplicationForm = (props: {
@@ -45,7 +41,6 @@ export const CreditApplicationForm = (props: {
   const [files, setFiles] = useState<FileWithPath[]>([]);
   const [attachments, setAttachments] = useState<FileWithPath[]>([]);
   const [error, setError] = useState<string>("");
-  const [showUploadSuccess, setShowUploadSuccess] = useState(false);
 
   useEffect(() => {
     const loadPrev = async () => {
@@ -60,7 +55,6 @@ export const CreditApplicationForm = (props: {
           return new File([file.data], file.fileName);
         });
         setFiles([toSet[0]]);
-        setShowUploadSuccess(true);
         if (toSet.length > 1) {
           setAttachments(toSet.slice(1));
         }
@@ -218,8 +212,8 @@ export const CreditApplicationForm = (props: {
   };
 
   return (
-    <div className="flex flex-col items-start self-stretch gap-4">
-      <div className="flex self-stretch items-center justify-between p-5 rounded-t bg-[#E7E7E7]">
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between p-5 rounded-t bg-[#E7E7E7]">
         <div className="text-black text-[26px] leading-7 font-bold">
           {props.creditApplication?.id
             ? `Credit Application ID ${props.creditApplication.id}`
@@ -233,61 +227,46 @@ export const CreditApplicationForm = (props: {
       </div>
 
       {getStatusBanner()}
-      <div className="self-stretch h-px bg-dividerMedium"></div>
+      <hr className="border-dividerMedium"></hr>
 
-      <div className="flex flex-col items-start gap-6 self-stretch bg-white">
-        {error && <p className="text-red-600">{error}</p>}
-
-        <div className="flex items-start gap-6 shadow-[0_2px_4px_0_rgba(0,0,0,0.08)]">
-          <div className="flex w-[619px] flex-col items-start rounded-sm border border-dividerMedium">
-            <div className="flex flex-col items-start self-stretch gap-1 rounded-t bg-disabledSurface px-5 py-4">
-              <div className="self-stretch text-black text-xl leading-7 font-bold">
-                Supplier Information
-              </div>
+      <div className="flex flex-col gap-6">
+        <div className="flex flex-col gap-6 self-start">
+          <div className="flex flex-col border border-dividerMedium rounded">
+            <div className="px-5 py-4 text-xl font-bold bg-disabledBG">
+              Supplier Information
             </div>
-            <div className="flex flex-col items-start gap-5 rounded p-5 shadow-[0_4px_20px_0_rgba(177,177,177,0.10)]">
-              <div className="flex flex-col items-start gap-3">
-                <div className="flex items-center gap-4 self-stretch">
-                  <div className="font-semibold w-[200px]">Legal Name:</div>{" "}
-                  <div className="w-[345px]">{props.legalName}</div>
-                </div>
-                <div className="w-[561px] h-px bg-disabledSurface"></div>
-                <div className="flex items-center gap-4 self-stretch">
-                  <div className="font-semibold w-[200px]">Record Address:</div>{" "}
-                  <div className="w-[345px]">{props.recordsAddress}</div>
-                </div>
-                <div className="w-[561px] h-px bg-disabledSurface"></div>
-                <div className="flex items-center gap-4 self-stretch">
-                  <div className="font-semibold w-[200px]">Service Address:</div>{" "}
-                  <div className="w-[345px]">{props.serviceAddress}</div>
-                </div>
-                <div className="w-[561px] h-px bg-disabledSurface"></div>
-                <div className="flex items-center gap-4 self-stretch">
-                  <div className="font-semibold w-[200px]">Makes:</div>{" "}
-                  <div className="w-[345px]">{props.makes}</div>
-                </div>
-              </div>
+            <div className="p-5 grid grid-cols-2 items-center gap-y-3">
+              <div className="font-bold">Legal Name:</div>
+              <div>{props.legalName}</div>
+              <hr className="col-span-2 border-disabledBG"></hr>
+              <div className="font-bold">Records Address:</div>
+              <div>{props.recordsAddress}</div>
+              <hr className="col-span-2 border-disabledBG"></hr>
+              <div className="font-bold">Service Address:</div>
+              <div>{props.serviceAddress}</div>
+              <hr className="col-span-2 border-disabledBG"></hr>
+              <div className="font-bold">Makes:</div>
+              <div>{props.makes}</div>
             </div>
           </div>
         </div>
 
-        <div className="flex flex-col items-start self-stretch rounded border border-dividerMedium shadow-[0_2px_4px_0_rgba(0,0,0,0.08)]">
-          <div className="flex flex-col items-start self-stretch gap-1 rounded-t bg-disabledSurface px-5 py-4">
-            <div className="self-stretch text-black text-xl leading-7 font-bold">
-              Credit Application Details
-            </div>
+        <div className="flex flex-col rounded border border-dividerMedium">
+          <div className="px-5 py-4 text-xl font-bold bg-disabledSurface">
+            Credit Application Details
           </div>
 
-          <div className="flex flex-col items-start self-stretch gap-2 px-5 py-4 rounded-t bg-[#F4F4F4]">
-            <div className="self-stretch text-black text-sm font-bold">
+          <div className="flex flex-col gap-2 px-5 py-4 rounded-t bg-[#F4F4F4]">
+            <span className="text-sm font-bold">
               Step 1: Download the Credit Application Template
-            </div>
-            <p className="text-sm text-secondaryText">
-              Use this template to complete your credit application before uploading.
-            </p>
+            </span>
+            <span className="text-sm">
+              Use this template to complete your credit application before
+              uploading.
+            </span>
           </div>
 
-          <div className="flex flex-col items-start self-stretch gap-5 p-5 rounded shadow-[0_4px_20px_0_rgba(177,177,177,0.10)]">
+          <div className="flex flex-row justify-start p-5">
             <Button
               variant="secondary"
               onClick={handleDownload}
@@ -298,117 +277,65 @@ export const CreditApplicationForm = (props: {
             </Button>
           </div>
 
-          <div className="self-stretch h-px bg-disabledSurface"></div>
-
-          <div className="flex flex-col items-start self-stretch gap-2 px-5 py-4 rounded-t bg-[#F4F4F4]">
-            <div className="self-stretch text-black text-sm font-bold">
+          <div className="flex flex-col gap-2 px-5 py-4 rounded-t bg-[#F4F4F4]">
+            <span className="text-sm font-bold">
               Step 2: Upload Credit Application
-            </div>
-            <p className="text-sm text-secondaryText">
+            </span>
+            <span className="text-sm">
               Upload the completed file using template above.
-            </p>
+            </span>
           </div>
 
-          <div className="flex flex-col items-start self-stretch gap-3 p-5">
-            {showUploadSuccess && files.length > 0 ? (
-              <>
-                <StatusBanner
-                  title="File uploaded successfully."
-                  primaryText="Review the data below before saving. To upload a new file, delete the current one."
-                />
-                <div className="self-stretch pointer-events-none">
-                  <Dropzone
-                    files={[]}
-                    setFiles={setFiles}
-                    disabled
-                    maxNumberOfFiles={1}
-                  />
-                </div>
-                <div className="self-stretch h-px bg-disabledSurface"></div>
-                <table className="w-full table-fixed text-sm">
-                  <thead>
-                    <tr className="border-gray-200">
-                      <th className="w-1/3 text-left py-2 font-semibold">Uploaded File</th>
-                      <th className="w-1/3 text-center py-2 font-semibold">Size</th>
-                      <th className="w-1/3 text-right py-2 font-semibold">Delete</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr>
-                      <td className="py-2">{files[0].name}</td>
-                      <td className="py-2 text-center">{fileSize} KB</td>
-                      <td className="py-2 text-right">
-                        <button
-                          type="button"
-                          onClick={() => {
-                            setFiles([]);
-                            setShowUploadSuccess(false);
-                          }}
-                          disabled={isPending}
-                          className="text-red-500 hover:text-red-700 disabled:opacity-50 bg-transparent border-none p-0"
-                        >
-                          <FontAwesomeIcon icon={faTrash} />
-                        </button>
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
-              </>
-            ) : (
-              <div className="self-stretch">
-                <Dropzone
-                  files={files}
-                  setFiles={setFiles}
-                  disabled={isPending}
-                  maxNumberOfFiles={1}
-                  allowedFileTypes={{
-                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":
-                      [".xlsx"],
-                  }}
-                  handleDrop={(acceptedFiles) => {
-                    if (acceptedFiles.length > 0) {
-                      setShowUploadSuccess(true);
-                    }
-                  }}
-                />
-              </div>
+          <div className="flex flex-col gap-3 p-5">
+            {files.length > 0 && (
+              <StatusBanner
+                title="File uploaded successfully."
+                primaryText="Review the data below before saving. To upload a new file, delete the current one."
+              />
             )}
+            <Dropzone
+              files={files}
+              setFiles={setFiles}
+              disabled={isPending}
+              maxNumberOfFiles={1}
+              allowedFileTypes={{
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":
+                  [".xlsx"],
+              }}
+            />
           </div>
         </div>
 
-        <div className="flex items-start self-stretch gap-6 shadow-[0_2px_4px_0_rgba(0,0,0,0.08)]">
-          <div className="flex flex-1 flex-col items-start rounded border border-dividerMedium">
-            <div className="flex flex-col items-start self-stretch gap-1 rounded-t bg-disabledSurface px-5 py-4">
-              <div className="self-stretch text-black text-xl leading-7 font-bold">
-                Supporting Documents (optional)
-              </div>
-            </div>
-            <div className="flex flex-col items-start self-stretch gap-3 p-5">
-              <div className="self-stretch">
-                <Dropzone
-                  files={attachments}
-                  setFiles={setAttachments}
-                  disabled={isPending}
-                  maxNumberOfFiles={10}
-                />
-              </div>
-            </div>
+        <div className="flex flex-col rounded border border-dividerMedium">
+          <div className="bg-disabledSurface px-5 py-4 text-xl font-bold">
+            Supporting Documents (optional)
+          </div>
+          <div className="p-5">
+            <Dropzone
+              files={attachments}
+              setFiles={setAttachments}
+              disabled={isPending}
+              maxNumberOfFiles={10}
+            />
           </div>
         </div>
 
-        <div className="flex items-center justify-between self-stretch pb-2">
+        <div className="flex flex-row items-center justify-between p-5 bg-lightGrey">
           <Button variant="secondary" onClick={handleBack} disabled={isPending}>
             ← Back
           </Button>
-          <Button
-            variant="primary"
-            onClick={handleSave}
-            disabled={isPending || files.length === 0}
-            icon={<FontAwesomeIcon icon={faFloppyDisk} />}
-            iconPosition="right"
-          >
-            Save
-          </Button>
+          <div className="flex flex-row gap-3 items-center">
+            {error && <p className="text-red-600">{error}</p>}
+            <Button
+              variant="primary"
+              onClick={handleSave}
+              disabled={isPending || files.length === 0}
+              icon={<FontAwesomeIcon icon={faFloppyDisk} />}
+              iconPosition="right"
+            >
+              Save
+            </Button>
+          </div>
         </div>
       </div>
     </div>

--- a/next/app/zev-unit-activities/lib/credit-applications/components/IndividualPage.tsx
+++ b/next/app/zev-unit-activities/lib/credit-applications/components/IndividualPage.tsx
@@ -145,119 +145,73 @@ export const IndividualPage = async (props: { id: string }) => {
   }
 
   return (
-    <div className="flex flex-col items-start self-stretch gap-4">
-      <div className="flex self-stretch items-center justify-between p-5 rounded-t bg-[#E7E7E7]">
-        <div className="text-black text-[26px] leading-7 font-bold">
-          Credit Application ID {id}
-        </div>
-        <div className="flex h-10 items-center justify-center gap-2 px-4 py-[5px]">
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-row items-center justify-between p-5 rounded-t bg-[#E7E7E7]">
+        <div className="text-[26px] font-bold">Credit Application ID {id}</div>
+        <div className="px-4 py-1">
           <PrintDownloadButton icon={<FontAwesomeIcon icon={faDownload} />}>
             Print/Download Page
           </PrintDownloadButton>
         </div>
       </div>
 
-      {statusBanner && 
-        <>
-          {statusBanner}
-        </>}
-      <div className="self-stretch h-px bg-dividerMedium"></div>
-      <div className="flex flex-col items-start gap-6 self-stretch bg-white">
-        <div className="flex items-start gap-6 shadow-[0_2px_4px_0_rgba(0,0,0,0.08)]">
-          <div className="flex w-[619px] flex-col items-start rounded-sm border border-dividerMedium">
-            <div className="flex flex-col items-start self-stretch gap-1 rounded-t bg-disabledSurface px-5 py-4">
-              <div className="self-stretch text-black text-xl leading-7 font-bold">
-                Supplier Information
-              </div>
-            </div>
-            <div className="flex flex-col items-start gap-5 rounded p-5 shadow-[0_4px_20px_0_rgba(177,177,177,0.10)]">
-              <div className="flex flex-col items-start gap-3">
-                <div className="flex items-center gap-4 self-stretch">
-                  <div className="font-semibold w-[200px]">Legal Name:</div>{" "}
-                  <div className="w-[345px]">{creditApplication.legalName}</div>
-                </div>
-                <div className="w-[561px] h-px bg-disabledSurface"></div>
-                <div className="flex items-center gap-4 self-stretch">
-                  <div className="font-semibold w-[200px]">Record Address:</div>{" "}
-                  <div className="w-[345px]">{creditApplication.recordsAddress}</div>
-                </div>
-                <div className="w-[561px] h-px bg-disabledSurface"></div>
-                <div className="flex items-center gap-4 self-stretch">
-                  <div className="font-semibold w-[200px]">Service Address:</div>{" "}
-                  <div className="w-[345px]">{creditApplication.serviceAddress}</div>
-                </div>
-                <div className="w-[561px] h-px bg-disabledSurface"></div>
-                <div className="flex items-center gap-4 self-stretch">
-                  <div className="font-semibold w-[200px]">Makes:</div>{" "}
-                  <div className="w-[345px]">{creditApplication.makes}</div>
-                </div>
-              </div>
-            </div>
+      {statusBanner && <>{statusBanner}</>}
+      <hr className="border-dividerMedium"></hr>
+      <div className="flex flex-col gap-6 self-start">
+        <div className="flex flex-col border border-dividerMedium rounded">
+          <div className="px-5 py-4 text-xl font-bold bg-disabledBG">
+            Supplier Information
+          </div>
+          <div className="p-5 grid grid-cols-2 items-center gap-y-3">
+            <div className="font-bold">Legal Name:</div>
+            <div>{creditApplication.legalName}</div>
+            <hr className="col-span-2 border-disabledBG"></hr>
+            <div className="font-bold">Records Address:</div>
+            <div>{creditApplication.recordsAddress}</div>
+            <hr className="col-span-2 border-disabledBG"></hr>
+            <div className="font-bold">Service Address:</div>
+            <div>{creditApplication.serviceAddress}</div>
+            <hr className="col-span-2 border-disabledBG"></hr>
+            <div className="font-bold">Makes:</div>
+            <div>{creditApplication.makes}</div>
           </div>
         </div>
+      </div>
 
-        <div className="flex flex-col items-start self-stretch rounded border border-dividerMedium shadow-[0_2px_4px_0_rgba(0,0,0,0.08)]">
-          <div className="flex flex-col items-start self-stretch">
-            <div className="flex flex-col items-start self-stretch gap-2 px-5 py-4 rounded-t border-b border-dividerMedium bg-disabledSurface">
-              <div className="self-stretch text-primaryText text-xl leading-7 font-bold">
-                Credit Application Details
-              </div>
-            </div>
-            <div className="flex flex-col items-start self-stretch gap-3 p-5">
-              <div className="flex items-center gap-4 self-stretch">
-                <div className="w-[138px] text-secondaryText leading-6 font-normal">
-                  Credit Application: 
-                </div>
-                <div className="flex-1 self-stretch text-link leading-6 font-normal underline">
-                  {creditApplication.fileName}
-                </div>
-              </div>
-              <div className="self-stretch h-px bg-disabledSurface"></div>
-              <div className="flex items-center">
-                <Attachments
-                  attachments={[{ fileName: creditApplication.fileName }]}
-                  download={downloadApplication}
-                  zipName={`credit-application-${id}`}
-                  className="[&_ul]:hidden"
-                  />
-              </div>
-              <div className="self-stretch h-px bg-disabledSurface"></div>
-            </div>
-          </div>
-          <Suspense fallback={<LoadingSkeleton />}>
-            <ApplicationStatistics
-              creditApplicationId={id}
-              userIsGov={false}
-            />
-          </Suspense>
+      <div className="flex flex-col rounded border border-dividerMedium">
+        <div className="px-5 py-4 text-xl font-bold bg-disabledSurface">
+          Credit Application Details
         </div>
+        <Attachments
+          attachments={[{ fileName: creditApplication.fileName }]}
+          download={downloadApplication}
+          zipName={`credit-application-${id}`}
+          includeBottomBorder={true}
+        />
+        <Suspense fallback={<LoadingSkeleton />}>
+          <ApplicationStatistics creditApplicationId={id} userIsGov={false} />
+        </Suspense>
+      </div>
 
-        <div className="flex items-start self-stretch gap-6 shadow-[0_2px_4px_0_rgba(0,0,0,0.08)]">
-          <div className="flex flex-1 flex-col items-start rounded border border-dividerMedium">
-            <div className="flex flex-col items-start self-stretch gap-1 rounded-t bg-disabledSurface px-5 py-4">
-              <div className="self-stretch text-black text-xl font-bold leading-7">
-                Supporting Documents (optional)
-              </div>
-            </div>
-            <Attachments
-              attachments={creditApplication.CreditApplicationAttachment}
-              download={downloadAttachments}
-              zipName={`credit-application-attachments-${id}`}
-              className="flex flex-col items-start self-stretch gap-3 p-5"
-              label="Proof of Range: "
-            />
-          </div>
+      <div className="flex flex-col rounded border border-dividerMedium">
+        <div className="px-5 py-4 text-xl font-bold bg-disabledSurface">
+          Supporting Documents (optional)
         </div>
-
-        <SupplierActions
-          creditApplicationId={id}
-          status={applicationSupplierStatus}
-          userRoles={userRoles}
-          hasInvalidatedRecords={
-            creditApplication._count.CreditApplicationRecord > 0
-          }
+        <Attachments
+          attachments={creditApplication.CreditApplicationAttachment}
+          download={downloadAttachments}
+          zipName={`credit-application-attachments-${id}`}
         />
       </div>
+
+      <SupplierActions
+        creditApplicationId={id}
+        status={applicationSupplierStatus}
+        userRoles={userRoles}
+        hasInvalidatedRecords={
+          creditApplication._count.CreditApplicationRecord > 0
+        }
+      />
     </div>
   );
 };

--- a/next/app/zev-unit-activities/lib/credit-applications/components/SupplierActions.tsx
+++ b/next/app/zev-unit-activities/lib/credit-applications/components/SupplierActions.tsx
@@ -132,30 +132,34 @@ export const SupplierActions = (props: {
     [handleDelete, handleSubmit],
   );
 
-  const canAddComment = props.userRoles.includes(Role.SIGNING_AUTHORITY);
+  const isSigningAuthority = props.userRoles.includes(Role.SIGNING_AUTHORITY);
 
   if (props.status === CreditApplicationSupplierStatus.DRAFT) {
     return (
       <>
-        {canAddComment && (
+        {isSigningAuthority && (
           <CommentBox comment={comment} setComment={setComment} />
         )}
-        {error && <p className="text-red-600 mb-2">{error}</p>}
-        <div className="flex self-stretch h-20 items-center justify-between p-5 bg-lightGrey gap-4">
-          <Button variant="secondary" onClick={handleBack}>
-            ← Back
-          </Button>
-          <Button variant="danger" onClick={() => showModal("delete")}>
-            Delete
-          </Button>
-          <Button variant="secondary" onClick={handleGoToEdit}>
-            Edit
-          </Button>
-          <div className="flex-1" />
-          {canAddComment && (
-            <Button variant="primary" onClick={() => showModal("submit")}>
-              Submit
+
+        <div className="flex flex-row items-center justify-between p-5 bg-lightGrey">
+          <div className="flex flex-row items-center gap-4">
+            <Button variant="secondary" onClick={handleBack}>
+              ← Back
             </Button>
+            <Button variant="danger" onClick={() => showModal("delete")}>
+              Delete
+            </Button>
+            <Button variant="secondary" onClick={handleGoToEdit}>
+              Edit
+            </Button>
+          </div>
+          {isSigningAuthority && (
+            <div className="flex flex-row items-center gap-4">
+              {error && <p className="text-red-600 mb-2">{error}</p>}
+              <Button variant="primary" onClick={() => showModal("submit")}>
+                Submit
+              </Button>
+            </div>
           )}
           {modal}
         </div>
@@ -165,8 +169,7 @@ export const SupplierActions = (props: {
 
   if (props.status === CreditApplicationSupplierStatus.SUBMITTED) {
     return (
-      <div className="flex self-stretch h-20 items-center justify-between p-5 bg-lightGrey">
-        {error && <p className="text-red-600 mb-2">{error}</p>}
+      <div className="flex flex-row items-center justify-start p-5 bg-lightGrey">
         <Button variant="secondary" onClick={handleBack}>
           ← Back
         </Button>
@@ -176,19 +179,18 @@ export const SupplierActions = (props: {
 
   if (props.status === CreditApplicationSupplierStatus.REJECTED) {
     return (
-      <>
-        {error && <p className="text-red-600 mb-2">{error}</p>}
-        <div className="flex self-stretch h-20 items-center justify-between p-5 bg-lightGrey">
-          <Button variant="secondary" onClick={handleBack}>
-            ← Back
-          </Button>
-          <div className="flex-1" />
+      <div className="flex flex-row items-center justify-between p-5 bg-lightGrey">
+        <Button variant="secondary" onClick={handleBack}>
+          ← Back
+        </Button>
+        <div className="flex flex-row items-center gap-4">
+          {error && <p className="text-red-600 mb-2">{error}</p>}
           <Button variant="danger" onClick={() => showModal("delete")}>
             Delete
           </Button>
-          {modal}
         </div>
-      </>
+        {modal}
+      </div>
     );
   }
 
@@ -197,25 +199,26 @@ export const SupplierActions = (props: {
     props.hasInvalidatedRecords
   ) {
     return (
-      <div className="flex self-stretch h-20 items-center justify-between p-5 bg-lightGrey">
-        {error && <p className="text-red-600 mb-2">{error}</p>}
+      <div className="flex flex-row items-center justify-between p-5 bg-lightGrey">
         <Button variant="secondary" onClick={handleBack}>
           ← Back
         </Button>
-        <div className="flex-1" />
-        <Button
-          variant="primary"
-          onClick={handleDownloadErrors}
-          disabled={isPending}
-        >
-          {isPending ? "..." : "Download VIN Errors"}
-        </Button>
+        <div className="flex flex-row items-center gap-4">
+          {error && <p className="text-red-600 mb-2">{error}</p>}
+          <Button
+            variant="primary"
+            onClick={handleDownloadErrors}
+            disabled={isPending}
+          >
+            {isPending ? "..." : "Download VIN Errors"}
+          </Button>
+        </div>
       </div>
     );
   }
 
   return (
-    <div className="flex self-stretch h-20 items-center justify-between p-5 bg-lightGrey">
+    <div className="flex flex-row items-center justify-start p-5 bg-lightGrey">
       <Button variant="secondary" onClick={handleBack}>
         ← Back
       </Button>


### PR DESCRIPTION
Hi @dallascrichmond, this PR contains some suggested changes to your 482 PR:

(1) Removal of more redundant utility classes; mainly, `items-start` on flex containers and `self-stretch` on flex items within the flex container; these two cancel each other out and so they can both be removed (flex items stretching across the cross axis is the default, desired behaviour).

(2) The `Attachments` common component: I spoke to Dan and Lalita about this in relation to another card a while back about how it doesn't make sense to add labels to attachment since there's no place to input those labels.

(3) Some formatting

I'll be writing up a document that will contain some guidelines/suggestions on how to approach styling things using Tailwind; I'll probably set up a meeting for us (you, me, Julian, Lalita); stay tuned!

Anyways, please have a look at these changes, and if they look okay to you, you can merge it in (this PR is targeted against your `482-fix` branch). After that, I'll merge your PR in!